### PR TITLE
Solução para urllib2.HTTPError: HTTP Error 403: Forbidden.

### DIFF
--- a/covid19_affectedcountries.py
+++ b/covid19_affectedcountries.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+#===============================================================================
+# IDENTIFICATION DIVISION
+#        ID SVN:   $Id$
+#          FILE:  covid9_status.py
+#         USAGE:  $0
+#   DESCRIPTION:  Get Worldometers Coronavirus / Covid9 affected contry list
+#  REQUIREMENTS:  pandas (pip install pandas)
+#                 lxml (pip install lxml)
+#          BUGS:  ---
+#         NOTES:  ---
+#          TODO:  ---
+#        AUTHOR:  Ricardo Barbosa, rickkbarbosa@live.com
+#       COMPANY:  ---
+#       VERSION:  1.0
+#       CREATED:  2020-Mar-10 08:57 BRT
+#      REVISION:  ---
+#===============================================================================
+
+import pandas as pd
+import json
+import requests
+
+url = 'https://www.worldometers.info/coronavirus/#countries'
+header = {"User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.75 Safari/537.36","X-Requested-With": "XMLHttpRequest"}
+
+r = requests.get(url, headers=header)
+df = pd.read_html(r.text)[0]
+df = df['Country,Other']
+
+country_list = list()
+for i in range(0, len(df)):
+    country_list.append({"{#COUNTRY_NAME}": df[i]})
+
+print json.dumps({"data": country_list}, indent=4)

--- a/covid19_status.py
+++ b/covid19_status.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+#===============================================================================
+# IDENTIFICATION DIVISION
+#        ID SVN:   $Id$
+#          FILE:  covid9_status.py
+#         USAGE:  $0
+#   DESCRIPTION:  Get Worldometers Coronavirus / Covid9 data and print to JSON
+#  REQUIREMENTS:  pandas (pip install pandas)
+#                 lxml (pip install lxml)
+#          BUGS:  ---
+#         NOTES:  ---
+#          TODO:  ---
+#        AUTHOR:  Ricardo Barbosa, rickkbarbosa@live.com
+#       COMPANY:  ---
+#       VERSION:  1.0
+#       CREATED:  2020-Mar-10 21:47 BRT
+#      REVISION:  ---
+#===============================================================================
+
+import pandas as pd
+import requests
+
+url = 'https://www.worldometers.info/coronavirus/#countries'
+header = {"User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.75 Safari/537.36","X-Requested-With": "XMLHttpRequest"}
+
+r = requests.get(url, headers=header)
+df = pd.read_html(r.text, index_col=0)[0]
+df = df.fillna('0')
+df = df.to_json(orient='index')
+
+print(df)


### PR DESCRIPTION
Correções para os problemas de urllib2.HTTPError: HTTP Error 403: Forbidden.